### PR TITLE
Make curio/trio tests optional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,10 @@
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest  # noqa
 
 # noinspection PyProtectedMember
 from python_socks._resolver_async_aio import Resolver as AsyncioResolver
-# noinspection PyProtectedMember
-from python_socks._resolver_async_curio import Resolver as CurioResolver
-# noinspection PyProtectedMember
-from python_socks._resolver_async_trio import Resolver as TrioResolver
 # noinspection PyProtectedMember
 from python_socks._resolver_sync import SyncResolver
 from tests.config import (
@@ -24,6 +21,11 @@ from tests.mocks import sync_resolve_factory, async_resolve_factory
 from tests.proxy_server import ProxyConfig, ProxyServer
 
 
+@contextmanager
+def nullcontext():
+    yield None
+
+
 @pytest.fixture(scope='session', autouse=True)
 def patch_resolvers():
     p1 = mock.patch.object(
@@ -38,17 +40,30 @@ def patch_resolvers():
         new=async_resolve_factory(AsyncioResolver)
     )
 
-    p3 = mock.patch.object(
-        TrioResolver,
-        attribute='resolve',
-        new=async_resolve_factory(TrioResolver)
-    )
+    try:
+        # noinspection PyProtectedMember
+        from python_socks._resolver_async_trio import Resolver as TrioResolver
+    except ImportError:
+        p3 = nullcontext()
+    else:
+        p3 = mock.patch.object(
+            TrioResolver,
+            attribute='resolve',
+            new=async_resolve_factory(TrioResolver)
+        )
 
-    p4 = mock.patch.object(
-        CurioResolver,
-        attribute='resolve',
-        new=async_resolve_factory(CurioResolver)
-    )
+    try:
+        # noinspection PyProtectedMember
+        from python_socks._resolver_async_curio import (
+            Resolver as CurioResolver)
+    except ImportError:
+        p4 = nullcontext()
+    else:
+        p4 = mock.patch.object(
+            CurioResolver,
+            attribute='resolve',
+            new=async_resolve_factory(CurioResolver)
+        )
 
     with p1, p2, p3, p4:
         yield None

--- a/tests/test_core_socks_async_curio.py
+++ b/tests/test_core_socks_async_curio.py
@@ -1,10 +1,8 @@
 import ssl
 from typing import Optional
 
-import curio
-import curio.io
-import curio.ssl as curiossl
-import pytest  # noqa
+import pytest
+
 from yarl import URL  # noqa
 
 from python_socks import (
@@ -14,15 +12,19 @@ from python_socks import (
     ProxyConnectionError
 )
 from python_socks._proxy_async import AsyncProxy  # noqa
-from python_socks._resolver_async_curio import Resolver  # noqa
 from python_socks.async_ import ProxyChain
-from python_socks.async_.curio import Proxy
 from tests.config import (
     PROXY_HOST_IPV4, SOCKS5_PROXY_PORT, LOGIN, PASSWORD, SKIP_IPV6_TESTS,
     SOCKS5_IPV4_URL, SOCKS5_IPV4_URL_WO_AUTH, SOCKS5_IPV6_URL, SOCKS4_URL,
     HTTP_PROXY_URL, TEST_URL_IPV4, SOCKS5_IPV4_HOSTNAME_URL,
     TEST_HOST_PEM_FILE, TEST_URL_IPV4_HTTPS
 )
+
+curio = pytest.importorskip('curio')
+import curio.io  # noqa
+import curio.ssl as curiossl  # noqa
+from python_socks._resolver_async_curio import Resolver  # noqa
+from python_socks.async_.curio import Proxy  # noqa
 
 
 async def make_request(proxy: AsyncProxy, url: str,

--- a/tests/test_core_socks_async_trio.py
+++ b/tests/test_core_socks_async_trio.py
@@ -1,8 +1,7 @@
 import socket
 import ssl
-import trio  # noqa
+import pytest
 
-import pytest  # noqa
 from yarl import URL  # noqa
 
 from python_socks import (
@@ -13,10 +12,7 @@ from python_socks import (
 )
 
 from python_socks._proxy_async import AsyncProxy  # noqa
-from python_socks.async_.trio import Proxy
 from python_socks.async_ import ProxyChain
-# noinspection PyUnresolvedReferences,PyProtectedMember
-from python_socks._resolver_async_trio import Resolver
 
 from tests.config import (
     PROXY_HOST_IPV4, SOCKS5_PROXY_PORT, LOGIN, PASSWORD, SKIP_IPV6_TESTS,
@@ -24,6 +20,11 @@ from tests.config import (
     HTTP_PROXY_URL, TEST_URL_IPV4, SOCKS5_IPV4_HOSTNAME_URL,
     TEST_HOST_PEM_FILE, TEST_URL_IPV4_HTTPS
 )
+
+trio = pytest.importorskip('trio')
+from python_socks.async_.trio import Proxy  # noqa
+# noinspection PyUnresolvedReferences,PyProtectedMember
+from python_socks._resolver_async_trio import Resolver  # noqa
 
 
 async def make_request(proxy: AsyncProxy,

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,12 +1,9 @@
 import socket
 from unittest.mock import MagicMock, patch
 
-import curio
 import pytest
 
 from python_socks._resolver_async_aio import Resolver as AsyncioResolver
-from python_socks._resolver_async_trio import Resolver as TrioResolver
-from python_socks._resolver_async_curio import Resolver as CurioResolver
 from python_socks._resolver_sync import SyncResolver
 
 RET_FAMILY = socket.AF_INET
@@ -56,6 +53,9 @@ async def test_asyncio_resolver():
 
 @pytest.mark.trio
 async def test_trio_resolver():
+    pytest.importorskip('trio')
+    from python_socks._resolver_async_trio import Resolver as TrioResolver
+
     getaddrinfo = MagicMock()
     getaddrinfo.return_value = get_value_async()
     # with patch('trio.socket.getaddrinfo', return_value=get_value_async()):
@@ -67,6 +67,9 @@ async def test_trio_resolver():
 
 
 def test_curio_resolver():
+    curio = pytest.importorskip('curio')
+    from python_socks._resolver_async_curio import Resolver as CurioResolver
+
     getaddrinfo = MagicMock()
     getaddrinfo.return_value = get_value_async()
     to_patch = 'python_socks._resolver_async_curio.getaddrinfo'


### PR DESCRIPTION
Make it possible to successfully run the package's tests without having
curio or trio installed.  The relevant tests are skipped if the required
dependency is missing.