### PR TITLE
allow socks5h as an alternate scheme for socks5

### DIFF
--- a/python_socks/_helpers.py
+++ b/python_socks/_helpers.py
@@ -47,7 +47,7 @@ def parse_proxy_url(url):
     parsed = urlparse(url)
 
     scheme = parsed.scheme
-    if scheme == 'socks5':
+    if scheme in {'socks5', 'socks5h'}:
         proxy_type = ProxyType.SOCKS5
     elif scheme == 'socks4':
         proxy_type = ProxyType.SOCKS4


### PR DESCRIPTION
scoks5h is a convention in the curl world to indicate "use" of
proxy-host's dns to resolve the address of the destination address.

Since python-socks already has implemented support for
[DOMAIN](https://github.com/romis2012/python-socks/blob/master/python_socks/_proto/socks5.py#L20)
this additional scheme type can also be allowed.

this allows not having to maintain 2 url (with and without socck5h) in
the users of aiohttps-socks/python-socks/.. and requests