### PR TITLE
fix unexpected error when raise anyio.BrokenResourceError

### DIFF
--- a/python_socks/async_/anyio/_proxy.py
+++ b/python_socks/async_/anyio/_proxy.py
@@ -90,7 +90,7 @@ class AnyioProxy:
             msg = 'Could not connect to proxy {}:{} [{}]'.format(
                 self._proxy_host,
                 self._proxy_port,
-                e.strerror,
+                getattr(e, "strerror", str(e)),
             )
             raise ProxyConnectionError(e.errno, msg) from e
         except Exception:


### PR DESCRIPTION
fix #14 access to strerror attribute of anyio.BrokenResourceError will cause unexpected AttributeError