### PR TITLE
Allow authenticated SOCKS5 connections without a password

### DIFF
--- a/python_socks/_proto/socks5.py
+++ b/python_socks/_proto/socks5.py
@@ -65,7 +65,7 @@ class AuthMethodsRequest:
     def __init__(self, username: str, password: str):
         auth_methods = bytearray([AuthMethod.ANONYMOUS])
 
-        if username and password:
+        if username:
             auth_methods.append(AuthMethod.USERNAME_PASSWORD)
 
         self.auth_methods = auth_methods


### PR DESCRIPTION
Hi.
The SOCKS5 protocol does not require the password to be non-empty. Some SOCKS5 server implementations authenticate the client by a username only, so it makes no sense to require a user of the library to provide any non-empty password just to make authentication work.