### PR TITLE
Added argument - custom proxy Resolver (for Asyncio)

### DIFF
--- a/python_socks/async_/asyncio/v2/_proxy.py
+++ b/python_socks/async_/asyncio/v2/_proxy.py
@@ -30,6 +30,7 @@ class AsyncioProxy:
         proxy_ssl: ssl.SSLContext = None,
         forward: 'AsyncioProxy' = None,
         loop: asyncio.AbstractEventLoop = None,
+        resolver: Resolver = None
     ):
         if loop is not None:  # pragma: no cover
             warnings.warn(
@@ -53,7 +54,7 @@ class AsyncioProxy:
         self._proxy_ssl = proxy_ssl
         self._forward = forward
 
-        self._resolver = Resolver(loop=loop)
+        self._resolver = Resolver(loop=loop) if resolver is None else resolver
 
     async def connect(
         self,


### PR DESCRIPTION
This is prerequisite to use aiohttp with Custom DNS resolver.


```
import socket
import asyncio
import aiohttp

from aiohttp_socks import ProxyType, ProxyConnector
from python_socks.async_.asyncio._resolver import Resolver
from aiohttp import AsyncResolver

class CustomResolver(Resolver):

    def __init__(self, loop: asyncio.AbstractEventLoop):
        super().__init__(loop)
        self.resolver = AsyncResolver(loop, nameservers=['208.67.222.123'], udp_port=5353)

    async def resolve(self, host, port=0, family=socket.AF_UNSPEC):
        hosts = await self.resolver.resolve(host, port, family)
        return '', hosts[0]['host']

async def main():
    loop = asyncio.get_event_loop()
    resolver = CustomResolver(loop)
    proxy_host = '199.102.104.70'
    proxy_port = 4145

    connector = ProxyConnector(proxy_type=ProxyType.SOCKS5,
                               host=proxy_host,
                               port=proxy_port,
                               rdns=False,
                               proxy_resolver=resolver,
                               ssl=False
                               )
    async with aiohttp.ClientSession(connector=connector) as session:
        async with session.get("http://ipapi.co/json") as resp:
            print(await resp.json())


if __name__ == '__main__':
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
    asyncio.run(main())

```



