### PR TITLE
add winloop to is_uvloop_event_loop

### DIFF
--- a/python_socks/async_/asyncio/_proxy.py
+++ b/python_socks/async_/asyncio/_proxy.py
@@ -120,7 +120,10 @@ class AsyncioProxy(abc.AsyncProxy):
 
         def is_uvloop_event_loop():
             try:
-                from uvloop import Loop  # noqa
+                if sys.platform in ["win32", "cli", "cygwin"]:
+                    from winloop import Loop # noqa
+                else:
+                    from uvloop import Loop  # noqa
             except ImportError:
                 return False
             return isinstance(self._loop, Loop)


### PR DESCRIPTION
Wanted to see if I could incorporate [winloop](https://github.com/Vizonex/winloop) into the library's asyncio branch since winloop is a branch of uvloop for windows that I originally founded to speedup windows and I also use python_socks with it quite a lot and I thought this could be quite helpful for being able to safely close a proxy after use, 
if you want me to just make a separate function instead called `is_winloop_event_loop` I will gladly do so if that makes the code less confusing.

