### PR TITLE
Avoid leaking an open socket

### DIFF
--- a/python_socks/async_/asyncio/_connect.py
+++ b/python_socks/async_/asyncio/_connect.py
@@ -27,7 +27,7 @@ async def connect_tcp(
 
     try:
         await loop.sock_connect(sock=sock, address=address)
-    except Exception:
+    except OSError:
         sock.close()
         raise
     return sock

--- a/python_socks/async_/asyncio/_connect.py
+++ b/python_socks/async_/asyncio/_connect.py
@@ -25,7 +25,11 @@ async def connect_tcp(
     else:
         address = (host, port)  # type: ignore[assignment]
 
-    await loop.sock_connect(sock=sock, address=address)
+    try:
+        await loop.sock_connect(sock=sock, address=address)
+    except Exception:
+        sock.close()
+        raise
     return sock
 
 


### PR DESCRIPTION
When there's nothing listening at the proxy URL, this code:

    from python_socks.async_.asyncio import Proxy
    await Proxy.from_url(...).connect(host, port)

leads to this warning:

    ResourceWarning: unclosed <socket.socket fd=7, family=2, type=1, proto=0, laddr=('127.0.0.1', 49432)>

This is because the socket isn't closed when loop.sock_connect raises OSError.

Closing the socket removes the warning and avoids leaking an open socket.