### PR TITLE
Remove hard-coded headers from HTTP Proxy CONNECT

### DIFF
--- a/python_socks/_protocols/http.py
+++ b/python_socks/_protocols/http.py
@@ -95,8 +95,6 @@ class ConnectRequest:
     def dumps(self) -> bytes:
         buff = _Buffer()
         buff.append_line(f'CONNECT {self.host}:{self.port} HTTP/1.1')
-        buff.append_line(f'Host: {self.host}:{self.port}')
-        buff.append_line(f'User-Agent: {DEFAULT_USER_AGENT}')
 
         if self.username and self.password:
             auth = BasicAuth(self.username, self.password)


### PR DESCRIPTION
When comparing to other connection libraries like [requests](https://github.com/psf/requests/blob/c4c8e20289ab82edad55d2fc07b42cbf08ae1441/src/requests/adapters.py#L592), it looks like the only necessary header is "Proxy-Authorization". By removing "Host" and "User-Agent" the experience is similar to simpler packages, making it easier to debug certain flows.
Was there a specific reason to include these two headers in the first place?