### PR TITLE
Avoid leaking an open socket

### DIFF
--- a/python_socks/async_/trio/_connect.py
+++ b/python_socks/async_/trio/_connect.py
@@ -18,7 +18,11 @@ async def connect_tcp(
     if local_addr is not None:  # pragma: no cover
         await sock.bind(local_addr)
 
-    await sock.connect((host, port))
+    try:
+        await sock.connect((host, port))
+    except OSError:
+        sock.close()
+        raise
     return sock
 
 


### PR DESCRIPTION
When connecting through a socks proxy to a non-existing or non-functional server such as `example.com` with the trio implementation, a warning is raised:

```
ResourceWarning: unclosed <socket.socket fd=15, family=2, type=1, proto=0, laddr=('127.0.0.1', 63402)>
  import gc; gc.collect()
Object allocated at (most recent call last):
  File "python-3.13/lib/python3.13/site-packages/trio/_socket.py", lineno 381
    stdlib_socket = _stdlib_socket.socket(family, type, proto, fileno)
```

This is the same issue with trio as 2e4f5ca9 was with asyncio.