### PR TITLE
Fix socks5 reply reading

### DIFF
--- a/python_socks/_connectors/socks5_async.py
+++ b/python_socks/_connectors/socks5_async.py
@@ -72,7 +72,7 @@ class Socks5AsyncConnector(AsyncConnector):
 
     # noinspection PyMethodMayBeStatic
     async def _read_reply(self, stream: AsyncSocketStream) -> bytes:
-        data = await stream.read_exact(4)
+        data = await stream.read_exact(3)
         if data[0] != socks5.SOCKS_VER:
             return data
         if data[1] != socks5.ReplyCode.SUCCEEDED:
@@ -80,6 +80,7 @@ class Socks5AsyncConnector(AsyncConnector):
         if data[2] != socks5.RSV:
             return data
 
+        data += await stream.read_exact(1)
         addr_type = data[3]
 
         if addr_type == socks5.AddressType.IPV4:

--- a/python_socks/_connectors/socks5_sync.py
+++ b/python_socks/_connectors/socks5_sync.py
@@ -63,7 +63,7 @@ class Socks5SyncConnector(SyncConnector):
 
     # noinspection PyMethodMayBeStatic
     def _read_reply(self, stream: SyncSocketStream) -> bytes:
-        data = stream.read_exact(4)
+        data = stream.read_exact(3)
         if data[0] != socks5.SOCKS_VER:
             return data
         if data[1] != socks5.ReplyCode.SUCCEEDED:
@@ -71,6 +71,7 @@ class Socks5SyncConnector(SyncConnector):
         if data[2] != socks5.RSV:
             return data
 
+        data += stream.read_exact(1)
         addr_type = data[3]
 
         if addr_type == socks5.AddressType.IPV4:


### PR DESCRIPTION
Some socks5 servers only send the first three bytes of the reply when an error occurs. Python-socks tries to read four bytes and hangs.